### PR TITLE
Add support for SVG plots using IPython/Matplotlib

### DIFF
--- a/comint-mime.el
+++ b/comint-mime.el
@@ -81,11 +81,11 @@ where the content is to be inserted.")
   "Property list of image parameters for display.
 See Info node `(elisp)Image Descriptors'.")
 
-(defvar comint-mime-image-scalable nil
-  "Whether to prefer scalable images over raster images.
-Currently, this only has an effect in IPython, where it changes
-the generated Matplotlib figures from PNG to SVG format. This
-increases the figure quality at the cost of higher file sizes.")
+(defvar comint-mime-prefer-svg nil
+  "Whether to prefer SVG images over e.g. PNG images.
+This increases the figure quality at the cost of higher file
+sizes.  Currently, this only has an effect in IPython, where
+it changes the generated Matplotlib figures.")
 
 (defvar comint-mime-setup-function-alist nil
   "Alist of setup functions for comint-mime.
@@ -216,7 +216,7 @@ from `comint-mode', or interactively after starting the comint."
   (if (not python-shell--first-prompt-received)
       (add-hook 'python-shell-first-prompt-hook #'comint-mime-setup-python nil t)
     (python-shell-send-string-no-output
-     (format "%s\n__COMINT_MIME_setup('''%s''', scalable=%s)"
+     (format "%s\n__COMINT_MIME_setup('''%s''', prefer_svg=%s)"
              (with-temp-buffer
                (insert-file-contents
                 (expand-file-name "comint-mime.py"
@@ -225,7 +225,7 @@ from `comint-mode', or interactively after starting the comint."
              (if (listp comint-mime-enabled-types)
                  (string-join comint-mime-enabled-types ";")
                comint-mime-enabled-types)
-			 (if comint-mime-image-scalable "True" "False")))))
+             (if comint-mime-prefer-svg "True" "False")))))
 
 (push '(inferior-python-mode . comint-mime-setup-python)
       comint-mime-setup-function-alist)

--- a/comint-mime.el
+++ b/comint-mime.el
@@ -81,6 +81,12 @@ where the content is to be inserted.")
   "Property list of image parameters for display.
 See Info node `(elisp)Image Descriptors'.")
 
+(defvar comint-mime-image-scalable nil
+  "Whether to prefer scalable images over raster images.
+Currently, this only has an effect in IPython, where it changes
+the generated Matplotlib figures from PNG to SVG format. This
+increases the figure quality at the cost of higher file sizes.")
+
 (defvar comint-mime-setup-function-alist nil
   "Alist of setup functions for comint-mime.
 The keys should be major modes derived from `comint-mode'.  The
@@ -210,7 +216,7 @@ from `comint-mode', or interactively after starting the comint."
   (if (not python-shell--first-prompt-received)
       (add-hook 'python-shell-first-prompt-hook #'comint-mime-setup-python nil t)
     (python-shell-send-string-no-output
-     (format "%s\n__COMINT_MIME_setup('''%s''')"
+     (format "%s\n__COMINT_MIME_setup('''%s''', scalable=%s)"
              (with-temp-buffer
                (insert-file-contents
                 (expand-file-name "comint-mime.py"
@@ -218,7 +224,8 @@ from `comint-mode', or interactively after starting the comint."
                (buffer-string))
              (if (listp comint-mime-enabled-types)
                  (string-join comint-mime-enabled-types ";")
-               comint-mime-enabled-types)))))
+               comint-mime-enabled-types)
+			 (if comint-mime-image-scalable "True" "False")))))
 
 (push '(inferior-python-mode . comint-mime-setup-python)
       comint-mime-setup-function-alist)

--- a/comint-mime.py
+++ b/comint-mime.py
@@ -22,6 +22,7 @@ def __COMINT_MIME_setup(types, size_limit=4000):
 		MIME_TYPES = {
 			"image/png": encoding_workaround,
 			"image/jpeg": encoding_workaround,
+			"image/svg+xml": str.encode,
 			"text/latex": str.encode,
 			"text/html": str.encode,
 			"application/json": lambda d: json.dumps(d).encode(),
@@ -29,6 +30,7 @@ def __COMINT_MIME_setup(types, size_limit=4000):
 		enabled = MIME_TYPES if types == "all" else types.split(";")
 		ipython.enable_matplotlib("inline")
 		ipython.display_formatter.active_types = list(MIME_TYPES.keys())
+		ipython.run_line_magic("config", "InlineBackend.figure_formats = ['svg']")
 		for mime, encoder in MIME_TYPES.items():
 			ipython.display_formatter.formatters[mime].enabled = mime in enabled
 			ipython.mime_renderers[mime] = functools.partial(print_osc, mime, encoder)

--- a/comint-mime.py
+++ b/comint-mime.py
@@ -1,5 +1,5 @@
 # This file is part of https://github.com/astoff/comint-mime  -*- tab-width: 4; -*-
-def __COMINT_MIME_setup(types, size_limit=4000, scalable=False):
+def __COMINT_MIME_setup(types, size_limit=4000, prefer_svg=False):
 	import base64, functools, json, pathlib
 
 	def encoding_workaround(data):
@@ -30,7 +30,7 @@ def __COMINT_MIME_setup(types, size_limit=4000, scalable=False):
 		enabled = MIME_TYPES if types == "all" else types.split(";")
 		ipython.enable_matplotlib("inline")
 		ipython.display_formatter.active_types = list(MIME_TYPES.keys())
-		if scalable:
+		if prefer_svg:
 				ipython.run_line_magic("config", "InlineBackend.figure_formats = ['svg']")
 				import matplotlib; matplotlib.rcParams["figure.facecolor"] = (0, 0, 0, 0)
 		for mime, encoder in MIME_TYPES.items():

--- a/comint-mime.py
+++ b/comint-mime.py
@@ -1,5 +1,5 @@
 # This file is part of https://github.com/astoff/comint-mime  -*- tab-width: 4; -*-
-def __COMINT_MIME_setup(types, size_limit=4000):
+def __COMINT_MIME_setup(types, size_limit=4000, scalable=False):
 	import base64, functools, json, pathlib
 
 	def encoding_workaround(data):
@@ -30,7 +30,9 @@ def __COMINT_MIME_setup(types, size_limit=4000):
 		enabled = MIME_TYPES if types == "all" else types.split(";")
 		ipython.enable_matplotlib("inline")
 		ipython.display_formatter.active_types = list(MIME_TYPES.keys())
-		ipython.run_line_magic("config", "InlineBackend.figure_formats = ['svg']")
+		if scalable:
+				ipython.run_line_magic("config", "InlineBackend.figure_formats = ['svg']")
+				import matplotlib; matplotlib.rcParams["figure.facecolor"] = (0, 0, 0, 0)
 		for mime, encoder in MIME_TYPES.items():
 			ipython.display_formatter.formatters[mime].enabled = mime in enabled
 			ipython.mime_renderers[mime] = functools.partial(print_osc, mime, encoder)


### PR DESCRIPTION
This pull request resolves issue #20:

- It fixes a bug whereby Matplotlib plots "disappear" in `comint-mime` buffers if you choose to turn on SVG output in IPython/Matplotlib.
- It also turns on SVG support in IPython by default, since this significantly improves the image quality.

For comparison with #20, the same example looks like this after this PR:
<img width="682" alt="Screenshot 2024-04-24 at 17 44 33" src="https://github.com/astoff/comint-mime/assets/271284/6599c94f-5736-4b53-8aba-497648855463">
